### PR TITLE
(GH-20) Update links and repository information

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,7 +7,7 @@
   "contributors": [],
   "contributorsPerLine": 7,
   "projectName": "Cake.7zip",
-  "projectOwner": "nils-a",
+  "projectOwner": "cake-contrib",
   "repoType": "github",
   "repoHost": "https://github.com"
 }

--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -2,7 +2,7 @@
   "generator-cake-addin": {
     "promptValues": {
       "projectName": "7zip",
-      "repositoryOwner": "nils-a",
+      "repositoryOwner": "cake-contrib",
       "projectMaintainer": "nils-a",
       "author": "Nils Andresen",
       "description": "makes 7zip available as a tool in cake",

--- a/src/Cake.7zip/Cake.7zip.csproj
+++ b/src/Cake.7zip/Cake.7zip.csproj
@@ -18,10 +18,10 @@
     <Description>makes 7zip available as a tool in cake</Description>
     <PackageIconUrl></PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://nils-a.github.io/Cake.7zip</PackageProjectUrl>
+    <PackageProjectUrl>https://cake-contrib.github.io/Cake.7zip</PackageProjectUrl>
     <PackageTags>cake;addin;SevenZip</PackageTags>
-    <RepositoryUrl>https://github.com/nils-a/Cake.7zip.git</RepositoryUrl>
-    <PackageReleaseNotes>https://github.com/nils-a/Cake.7zip/releases/tag/</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/cake-contrib/Cake.7zip.git</RepositoryUrl>
+    <PackageReleaseNotes>https://github.com/cake-contrib/Cake.7zip/releases</PackageReleaseNotes>
     <RootNamespace>Cake.SevenZip</RootNamespace>
     <Version>0.0.1</Version>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
There were some links to nils-a, which is where the repository started
out, but they needed to be updated when transferred to cake-contrib
Organisation.

Fixes #20