### PR TITLE
release/0.5.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 
 pull_requests:
   do_not_increment_build_number: true

--- a/.github/workflows/publishDocs.yml
+++ b/.github/workflows/publishDocs.yml
@@ -1,0 +1,25 @@
+name: Publish Documentation
+
+on:
+  workflow_dispatch
+
+env:
+  WYAM_ACCESS_TOKEN: ${{ secrets.API_TOKEN }}
+  # secrets.GITHUB_TOKEN has no permissions to push, sadly.
+  WYAM_DEPLOY_BRANCH: 'gh-pages'
+  #WYAM_DEPLOY_REMOTE: does not exist in any context, will be dynamically set - see below
+
+jobs:
+  cake:
+    runs-on: windows-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2 #https://github.com/actions/checkout
+      with:
+        fetch-depth: 0 # GitVersion is somewhat irritated when fetch-depth is "1"....
+    
+    - name: call cake
+      run: |
+        $env:WYAM_DEPLOY_REMOTE = $( git remote get-url --push origin )
+        .\build.ps1 -Target PublishDocs -Verbosity Diagnostic

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Cake.Recipe&version=1.1.1
+#load nuget:?package=Cake.Recipe&version=1.1.2
 
 Environment.SetVariableNames();
 

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -234,36 +234,3 @@ dotnet_naming_style.camelcase.required_suffix =
 dotnet_naming_style.camelcase.word_separator = 
 dotnet_naming_style.camelcase.capitalization = camel_case
 
-## IDE
-
-# IDE0005: Using directive is unnecessary. (but ignore on auto-generated)
-dotnet_diagnostic.IDE0005.severity = warning
-dotnet_diagnostic.IDE0005_gen.severity = none
-
-# IDE0061: Misplaced using directive
-dotnet_diagnostic.IDE0061.severity = suggestion
-
-## SA... StyleCop
-
-# SA1200: Using directives should be placed correctly
-dotnet_diagnostic.SA1200.severity = none
-
-# SA1101: Prefix local calls with this
-dotnet_diagnostic.SA1101.severity = none
-
-# SA1633: File should have header
-dotnet_diagnostic.SA1633.severity = none
-
-## CA... FxCop
-
-# CA1062: Validate arguments of public methods
-dotnet_diagnostic.CA1062.severity = none
-
-# CA1303: Do not pass literals as localized parameters
-dotnet_diagnostic.CA1303.severity = none
-
-# CA1040: Avoid empty interfaces
-dotnet_diagnostic.CA1040.severity = none
-
-# CA1044: collides with r# - rules.
-dotnet_diagnostic.CA1044.severity = none

--- a/src/Cake.7zip.Tests/Cake.7zip.Tests.csproj
+++ b/src/Cake.7zip.Tests/Cake.7zip.Tests.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
         <TargetFrameworks Condition="'$(OS)'!='Unix'">$(TargetFrameworks);net461</TargetFrameworks>
+        <CodeAnalysisRuleSet>..\cake.7zip.ruleset</CodeAnalysisRuleSet>
 
         <IsPackable>false</IsPackable>
 

--- a/src/Cake.7zip/Cake.7zip.csproj
+++ b/src/Cake.7zip/Cake.7zip.csproj
@@ -26,6 +26,7 @@
         <RootNamespace>Cake.SevenZip</RootNamespace>
         <Version>0.0.1</Version>
         <PackageIcon>icon.png</PackageIcon>
+        <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Cake.7zip/Cake.7zip.csproj
+++ b/src/Cake.7zip/Cake.7zip.csproj
@@ -18,7 +18,6 @@
         <Authors>Nils Andresen</Authors>
         <Copyright>Copyright © $(FullYear) — Nils Andresen</Copyright>
         <Description>makes 7zip available as a tool in cake</Description>
-        <PackageIconUrl></PackageIconUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://cake-contrib.github.io/Cake.7zip</PackageProjectUrl>
         <PackageTags>cake;addin;SevenZip</PackageTags>

--- a/src/Cake.7zip/Cake.7zip.csproj
+++ b/src/Cake.7zip/Cake.7zip.csproj
@@ -5,6 +5,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <CodeAnalysisRuleSet>..\cake.7zip.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+ <PropertyGroup>
+   <!-- VS 2017 defaults to 7.0 -->
+   <LangVersion>7.3</LangVersion>
+ </PropertyGroup>
+</Project>

--- a/src/cake.7zip.ruleset
+++ b/src/cake.7zip.ruleset
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for Cake.7zip" ToolsVersion="16.0">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0005" Action="Warning" />
+    <Rule Id="IDE0005_gen" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1040" Action="None" />
+    <Rule Id="CA1044" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1303" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1200" Action="None" />
+    <Rule Id="SA1633" Action="None" />
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
- added a gh-action to update the docs
- bumped cake.recipe to 1.1.2
- switched appveyor image to vs 2019 and added PackageIconUrl for compatibility
