### PR TITLE
(maint) added .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# file scoped namespaces
+73dca7a5910495754d0ca0afa90d1d4420967f7b


### PR DESCRIPTION
and exclude the the move to file scoped namespaces
from git-blame.