### PR TITLE
Make all commands show logs

### DIFF
--- a/src/Cake.7zip/SevenZipRunner.cs
+++ b/src/Cake.7zip/SevenZipRunner.cs
@@ -57,20 +57,7 @@ public sealed class SevenZipRunner : Tool<SevenZipSettings>
             throw new ArgumentNullException(nameof(settings));
         }
 
-        var procSettings = new ProcessSettings
-        {
-            RedirectStandardOutput = true,
-        };
-
-        void AfterRun(IProcess p)
-        {
-            if (settings.Command is ICanParseOutput parseOutput)
-            {
-                parseOutput.SetRawOutput(p.GetStandardOutput());
-            }
-        }
-
-        Run(settings, GetArguments(settings), procSettings, AfterRun);
+        Run(settings, GetArguments(settings));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
With AfterRun or ProcessSettings, InAddMode, Cake will not be able to show any process output, So I try to remove this wired process log logic to allow all command show logs.