### PR TITLE
update renovate settings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [ "github>nils-a/renovate-config" ],
+  "extends": [
+    "github>cake-contrib/renovate-presets:cake-recipe",
+    "github>cake-contrib/renovate-presets:github-actions" ],
   "packageRules": [
     {
-      "matchPackageNames": ["cake.tool", "Cake.Core"],
+      "description": "Update Cake references only for major updates.",
+      "matchPackageNames": ["Cake.Core", "Cake.Common"],
+      "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
+    },
+    {
+      "description": "Updates to Cake.Core references are breaking.",
+      "matchPackageNames": ["Cake.Core"],
+      "matchUpdateTypes": ["major"],
+      "labels": ["Breaking Change"]
     }
-  ]
+  ],
+  "milestone": 18
 }


### PR DESCRIPTION
* inherit from cake-contrib/renovate-presets:cake-recipe
* inherit from cake-contrib/renovate-presets:github-actions
* disable updating Cake, for non major updates
* add the "breaking change" label to all Cake major updates
* add the milestone vNext to each PR