### PR TITLE
remove milestone setting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,5 @@
       "matchUpdateTypes": ["major"],
       "labels": ["Breaking Change"]
     }
-  ],
-  "milestone": 18
+  ]
 }


### PR DESCRIPTION
it's only available in renovate version 37.204.0
but the GitHub bot currently is running version 37.200.0