### PR TITLE
(#388) Update Cake reference to Cake 5

### DIFF
--- a/demo/cake/.config/dotnet-tools.json
+++ b/demo/cake/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/demo/cake/build.cake
+++ b/demo/cake/build.cake
@@ -1,5 +1,5 @@
 #tool "nuget:?package=7-Zip.CommandLine&version=18.1.0"
-#r "..\..\src\Cake.7zip\bin\Release\net6.0\Cake.7zip.dll"
+#r "..\..\src\Cake.7zip\bin\Release\net8.0\Cake.7zip.dll"
 
 ///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <RunWorkingDirectory>$(MSBuildProjectDirectory)..</RunWorkingDirectory>
+    <TargetFramework>net8.0</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.7zip, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\..\src\Cake.7zip\bin\Release\net6.0\Cake.7zip.dll</HintPath>
+    <Reference Include="Cake.7zip">
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\src\Cake.7zip\bin\Release\net8.0\Cake.7zip.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="4.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="output\**" />

--- a/demo/frosting/build/Program.cs
+++ b/demo/frosting/build/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Cake.Frosting;
 
 namespace Build
@@ -8,10 +9,25 @@ namespace Build
         public static int Main(string[] args)
         {
             return new CakeHost()
-                .InstallTool(new Uri("nuget:?package=7-Zip.CommandLine&version=18.1.0"))
+                .InstallSevenZip()
                 .UseContext<BuildContext>()
                 .UseSetup<BuildSetup>()
                 .Run(args);
+        }
+
+        private static CakeHost InstallSevenZip(this CakeHost host)
+        {
+            // 7-Zip.CommandLine is a windows-only package
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                host.InstallTool(new Uri("nuget:?package=7-Zip.CommandLine&version=18.1.0"));
+            }
+            else
+            {
+                Console.WriteLine("7-Zip.CommandLine tool not installed. Make sure you hava a version of 7zip installed!");
+            }
+
+            return host;
         }
     }
 }

--- a/demo/frosting/build/Tasks/ZipItTask.cs
+++ b/demo/frosting/build/Tasks/ZipItTask.cs
@@ -12,7 +12,7 @@ namespace Build.Tasks
             context.SevenZip(m => m
                 .InAddMode()
                 .WithArchive(context.Output.CombineWithFilePath("archive.zip"))
-                .WithFiles(context.Root.CombineWithFilePath("README.MD"))
+                .WithFiles(context.Root.CombineWithFilePath("README.md"))
                 .WithFiles(context.Root.CombineWithFilePath("CODE_OF_CONDUCT.md")));
         }
     }

--- a/src/Cake.7zip.Tests/Cake.7zip.Tests.csproj
+++ b/src/Cake.7zip.Tests/Cake.7zip.Tests.csproj
@@ -6,7 +6,7 @@
             This is done to make Cake.Recipe avoid using OpenCover.                                                                                                                                                                                         Remove this hack if Cake.Recipe bumps the usage of Cake.Incubator to version 7.0.0
         -->
         <TargetFrameworks Condition="false">netcoreapp3.1</TargetFrameworks>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <CodeAnalysisRuleSet>..\cake.7zip.ruleset</CodeAnalysisRuleSet>
 
         <IsPackable>false</IsPackable>
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Testing" Version="4.0.0" />
+        <PackageReference Include="Cake.Testing" Version="5.0.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.2">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.7zip.Tests/SevenZipRunnerTests.cs
+++ b/src/Cake.7zip.Tests/SevenZipRunnerTests.cs
@@ -92,7 +92,7 @@ public class SevenZipRunnerTests
 
         var sevenZipKey = new Mock<IRegistryKey>();
         sevenZipKey.Setup(k => k.GetValue("Path")).Returns(installLocation.Path.FullPath);
-        sevenZipKey.Setup(k => k.GetValue("Path64")).Returns(null);
+        sevenZipKey.Setup(k => k.GetValue("Path64")).Returns(null!);
         var softwareKey = new Mock<IRegistryKey>();
         softwareKey.Setup(k => k.OpenKey("7-Zip")).Returns(sevenZipKey.Object);
         var hklm = new Mock<IRegistryKey>();
@@ -124,7 +124,7 @@ public class SevenZipRunnerTests
         var file = fixture.FileSystem.CreateFile(installLocation.Path.CombineWithFilePath("7z.exe"));
 
         var sevenZipKey = new Mock<IRegistryKey>();
-        sevenZipKey.Setup(k => k.GetValue("Path")).Returns(null);
+        sevenZipKey.Setup(k => k.GetValue("Path")).Returns(null!);
         sevenZipKey.Setup(k => k.GetValue("Path64")).Returns(installLocation.Path.FullPath);
         var softwareKey = new Mock<IRegistryKey>();
         softwareKey.Setup(k => k.OpenKey("7-Zip")).Returns(sevenZipKey.Object);

--- a/src/Cake.7zip/Cake.7zip.csproj
+++ b/src/Cake.7zip/Cake.7zip.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -39,8 +39,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
-        <PackageReference Include="CakeContrib.Guidelines" Version="1.5.1" PrivateAssets="All" />
+        <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+        <PackageReference Include="CakeContrib.Guidelines" Version="1.6.1" PrivateAssets="All" />
         <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
and CakeContrib.Guidelines to 1.6.1

fixes #388 