### PR TITLE
(#414) Bump reportGeneratorGlobalTool and coverallsGlobalTool

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -21,6 +21,8 @@ BuildParameters.PrintParameters(Context);
 ToolSettings.SetToolSettings(context: Context);
 ToolSettings.SetToolPreprocessorDirectives(
     gitReleaseManagerGlobalTool: "#tool dotnet:?package=GitReleaseManager.Tool&version=0.18.0",
-    gitVersionGlobalTool: "#tool dotnet:?package=GitVersion.Tool&version=5.12.0");
+    gitVersionGlobalTool: "#tool dotnet:?package=GitVersion.Tool&version=5.12.0",
+    reportGeneratorGlobalTool: "#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=5.4.7",
+    coverallsGlobalTool: "#tool dotnet:?package=coveralls.net&version=4.0.1");
 
 Build.RunDotNetCore();


### PR DESCRIPTION
Bump dotnet-reportgenerator-globaltool to 5.4.7
and coveralls.net to 4.0.1

fixes #414 