### PR TITLE
(#442) Bump References to Cake to v6.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,14 +52,15 @@ jobs:
           # codecov needs 2.1
           # unittests needs 3.1
           # gitversion needs 5.0
-          # cake 1.3 needs 6.0
-          # .NET 9 to build
+          # cake 2.3 needs 6.0
+          # .NET 10 to build
           dotnet-version: |
             2.1
             3.1
             5.0
             6.0
             9.0
+            10.0
       - name: Install mono
         if: runner.os == 'Linux'
         # check https://www.mono-project.com/download/stable/#download-lin

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,12 +37,12 @@ jobs:
     - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
       with:
         # gitversion needs 5.0
-        # cake 1.3 needs 6.0
-        # .NET 9 to build
+        # cake 2.3 needs 6.0
+        # .NET 10 to build
         dotnet-version: |
           5.0
           6.0
-          9.0
+          10.0
 
     - name: Install mono
       if: runner.os == 'Linux'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.306",
+      "version": "10.0.100",
       "rollForward": "latestFeature"
     }
   }

--- a/src/Cake.7zip.Tests/Cake.7zip.Tests.csproj
+++ b/src/Cake.7zip.Tests/Cake.7zip.Tests.csproj
@@ -6,7 +6,7 @@
             This is done to make Cake.Recipe avoid using OpenCover.                                                                                                                                                                                         Remove this hack if Cake.Recipe bumps the usage of Cake.Incubator to version 7.0.0
         -->
         <TargetFrameworks Condition="false">netcoreapp3.1</TargetFrameworks>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <CodeAnalysisRuleSet>..\cake.7zip.ruleset</CodeAnalysisRuleSet>
 
         <IsPackable>false</IsPackable>
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Testing" Version="5.0.0" />
+        <PackageReference Include="Cake.Testing" Version="6.0.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.7zip/Cake.7zip.csproj
+++ b/src/Cake.7zip/Cake.7zip.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -39,8 +39,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
-        <PackageReference Include="CakeContrib.Guidelines" Version="1.6.1" PrivateAssets="All" />
+        <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
+        <PackageReference Include="CakeContrib.Guidelines" Version="1.7.0" PrivateAssets="All" />
         <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Also Updated CakeContrib.Guidelines to 1.7.0 (which added support for Cake 6.0.0)
and set the TFM to match the requirements in Cake 6.0.0

fixes #442 