### PR TITLE
(#445) Set Windows as the preferred runner for publishes

### DIFF
--- a/.github/workflows/publishDocs.yml
+++ b/.github/workflows/publishDocs.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   cake:
-    runs-on: ubuntu-24.04
+    runs-on: windows-2022
 
     steps:
     - name: checkout
@@ -19,29 +19,24 @@ jobs:
 
     - name: Fetch all tags and branches
       run: git fetch --prune --unshallow
-
+    - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+      with:
+        # wyam needs 2.1
+        # cake 2.3 needs 6.0
+        # .NET 10 to build
+        dotnet-version: |
+          2.1
+          6.0
+          10.0
     - name: Cache Tools
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: tools
         key: ${{ runner.os }}-doc-tools-${{ hashFiles('recipe.cake') }}
 
-    - name: Install mono
-      if: runner.os == 'Linux'
-      # check https://www.mono-project.com/download/stable/#download-lin
-      run: |
-        sudo apt install ca-certificates gnupg
-        sudo gpg --homedir /tmp --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-        sudo chmod +r /usr/share/keyrings/mono-official-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt update
-        sudo apt install -y mono-complete
-        mono --version
-
     - name: Publishing documentaiton
       uses: cake-build/cake-action@d218f1133bb74a1df0b08c89cfd8fc100c09e1a0 # v3
       with:
         script-path: recipe.cake
         target: Force-Publish-Documentation
-        verbosity: Diagnostic
         cake-version: tool-manifest

--- a/recipe.cake
+++ b/recipe.cake
@@ -13,7 +13,7 @@ BuildParameters.SetParameters(
   shouldUseDeterministicBuilds: true,
   shouldRunCodecov: false,
   preferredBuildProviderType: BuildProviderType.GitHubActions,
-  preferredBuildAgentOperatingSystem: PlatformFamily.Linux,
+  preferredBuildAgentOperatingSystem: PlatformFamily.Windows,
   shouldUseTargetFrameworkPath: false);
 
 BuildParameters.PrintParameters(Context);


### PR DESCRIPTION
It seems the old Wyam version has a problem with the newer libssl in linux

fixes #445 